### PR TITLE
FIX empty string uri in add_reference()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
 
 setup(
     name='xmlsig',
-    version='0.1.1',
+    version='0.1.2',
     description='Python based XML signature',
     long_description='XML Signature created with cryptography and lxml',
     author="Enric Tobella Alomar",

--- a/src/xmlsig/template.py
+++ b/src/xmlsig/template.py
@@ -30,6 +30,8 @@ def add_reference(node, digest_method, name=False, uri=False, uri_type=False):
     )
     if name:
         reference.set(ID_ATTR, name)
+    if uri == "":
+        reference.set('URI', "")
     if uri:
         reference.set('URI', uri)
     if uri_type:


### PR DESCRIPTION
En algunos casos (nos ha pasado en algunas facturae) para calcular una firma válida, el elemento URI debe estar presente aunque sea un string vacío.