### PR TITLE
Remove install dependency on asn1 and cffi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ from setuptools import find_packages, setup
 install_requires = [
     "lxml>=3.0.0",
     "cryptography",
-    "asn1crypto",
-    "cffi",
 ]
 
 tests_require = [


### PR DESCRIPTION
They don't seem to be directly used anywhere in xmlsig