### PR TITLE
Make OpenSSL optional for real

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ jobs:
     pre-commit:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
               with:
                   python-version: 3.9
-            - uses: pre-commit/action@v2.0.0
+            - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
                       LXML_VERSION: "4.6.4"
                       os: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{matrix.PYTHON_VERSION}}
             - name: Configuration
@@ -56,4 +56,4 @@ jobs:
                   pip install .[test]
                   coverage run -m unittest
             - name: Upload Coverage to Codecov
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ tests_require = [
 
 setup(
     name="xmlsig",
-    version="1.0.0",
+    version="1.0.1",
     description="Python based XML signature",
     long_description="XML Signature created with cryptography and lxml",
     author="Enric Tobella Alomar",

--- a/src/xmlsig/signature_context.py
+++ b/src/xmlsig/signature_context.py
@@ -5,13 +5,17 @@ import base64
 import hashlib
 from os import path
 
-import OpenSSL
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import ExtensionOID
 from lxml import etree
 
 from . import constants
 from .utils import b64_print, create_node, get_rdns_name
+
+try:
+    import OpenSSL
+except ImportError:
+    OpenSSL = None
 
 
 class SignatureContext(object):
@@ -367,7 +371,7 @@ class SignatureContext(object):
         :type key: Union[OpenSSL.crypto.PKCS12, tuple]
         :return: None
         """
-        if isinstance(key, OpenSSL.crypto.PKCS12):
+        if OpenSSL is not None and isinstance(key, OpenSSL.crypto.PKCS12):
             # This would happen if we are using pyOpenSSL
             self.x509 = key.get_certificate().to_cryptography()
             self.public_key = key.get_certificate().to_cryptography().public_key()


### PR DESCRIPTION
OpenSSL is not an install_dependency, but installation fails if it's not present as it's unconditionally imported for signatures.

Change the import to be optional, in which case `load_pkcs12` will only support cryptography keys (as tuples).

Fixes #12